### PR TITLE
Add key validation

### DIFF
--- a/NATS.NKeys/PublicAPI.Unshipped.txt
+++ b/NATS.NKeys/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ NATS.NKeys.KeyPair.Dispose() -> void
 NATS.NKeys.KeyPair.GetPublicKey() -> string!
 NATS.NKeys.KeyPair.GetSeed() -> string!
 NATS.NKeys.KeyPair.Open(byte[]! input, string! sender) -> byte[]!
+NATS.NKeys.KeyPair.Prefix.get -> NATS.NKeys.PrefixByte
 NATS.NKeys.KeyPair.Seal(byte[]! data, string! receiver) -> byte[]!
 NATS.NKeys.KeyPair.Sign(System.ReadOnlyMemory<byte> message, System.Memory<byte> signature) -> void
 NATS.NKeys.KeyPair.Verify(System.ReadOnlyMemory<byte> message, System.ReadOnlyMemory<byte> signature) -> bool
@@ -25,3 +26,4 @@ static NATS.NKeys.KeyPair.CreatePair(NATS.NKeys.PrefixByte prefix) -> NATS.NKeys
 static NATS.NKeys.KeyPair.CreatePair(NATS.NKeys.PrefixByte prefix, System.Security.Cryptography.RandomNumberGenerator! rng) -> NATS.NKeys.KeyPair!
 static NATS.NKeys.KeyPair.FromPublicKey(System.ReadOnlySpan<char> publicKey) -> NATS.NKeys.KeyPair!
 static NATS.NKeys.KeyPair.FromSeed(System.ReadOnlySpan<char> encodedSeed) -> NATS.NKeys.KeyPair!
+static NATS.NKeys.KeyPair.IsValidPublicKey(NATS.NKeys.PrefixByte prefix, System.ReadOnlySpan<char> publicKey) -> bool


### PR DESCRIPTION
This adds additional validation for public keys to support additional jwt.net checks.

see also https://github.com/nats-io/jwt.net/pull/33 which will be updated once this PR is released.