### PR TITLE
Fix exception handling in Open()

### DIFF
--- a/NATS.NKeys.Tests/NKeysTest.cs
+++ b/NATS.NKeys.Tests/NKeysTest.cs
@@ -468,7 +468,7 @@ public class NKeysTest(ITestOutputHelper output)
         var sealed1 = alice.Seal(Encoding.UTF8.GetBytes("secret"), bob.GetPublicKey());
 
         // Bob tries to open with Eve's public key as sender — must fail
-        Assert.ThrowsAny<Exception>(() => bob.Open(sealed1, eve.GetPublicKey()));
+        Assert.Throws<NKeysException>(() => bob.Open(sealed1, eve.GetPublicKey()));
     }
 
     [Fact]
@@ -482,7 +482,7 @@ public class NKeysTest(ITestOutputHelper output)
         var sealed1 = alice.Seal(Encoding.UTF8.GetBytes("secret"), bob.GetPublicKey());
 
         // Eve tries to open something meant for Bob
-        Assert.ThrowsAny<Exception>(() => eve.Open(sealed1, alice.GetPublicKey()));
+        Assert.Throws<NKeysException>(() => eve.Open(sealed1, alice.GetPublicKey()));
     }
 
     [Fact]
@@ -496,7 +496,7 @@ public class NKeysTest(ITestOutputHelper output)
         // Flip a byte in the encrypted payload (after version + nonce header)
         sealed1[30] ^= 0xFF;
 
-        Assert.ThrowsAny<Exception>(() => bob.Open(sealed1, alice.GetPublicKey()));
+        Assert.Throws<NKeysException>(() => bob.Open(sealed1, alice.GetPublicKey()));
     }
 
     [Fact]
@@ -515,6 +515,29 @@ public class NKeysTest(ITestOutputHelper output)
         // But both decrypt to the same message
         Assert.Equal(message, bob.Open(sealed1, alice.GetPublicKey()));
         Assert.Equal(message, bob.Open(sealed2, alice.GetPublicKey()));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(28)]
+    [InlineData(29)]
+    [InlineData(43)]
+    public void Open_rejects_short_input(int length)
+    {
+        var kp = KeyPair.CreatePair(PrefixByte.Curve);
+        var input = new byte[length];
+
+        // Fill with valid version header if long enough
+        if (length >= 4)
+        {
+            input[0] = (byte)'x';
+            input[1] = (byte)'k';
+            input[2] = (byte)'v';
+            input[3] = (byte)'1';
+        }
+
+        var ex = Assert.Throws<NKeysException>(() => kp.Open(input, kp.GetPublicKey()));
+        Assert.Equal("Encrypted input is not valid", ex.Message);
     }
 
     [Fact]

--- a/NATS.NKeys/KeyPair.cs
+++ b/NATS.NKeys/KeyPair.cs
@@ -286,7 +286,7 @@ public sealed class KeyPair : IDisposable
         {
             return TweetNaCl.CryptoBoxOpen(input.AsSpan().Slice(Vlen + CurveNonceLen).ToArray(), nonce, spub, _seed)!;
         }
-        catch (Exception ex) when (ex is not NKeysException)
+        catch (TweetNaCl.NKeyNaclException)
         {
             throw new NKeysException("Decryption failed");
         }

--- a/NATS.NKeys/KeyPair.cs
+++ b/NATS.NKeys/KeyPair.cs
@@ -267,7 +267,7 @@ public sealed class KeyPair : IDisposable
             throw new NKeysException("Curve key only operation");
         }
 
-        if (input.Length <= Vlen + CurveNonceLen)
+        if (input.Length < Vlen + CurveNonceLen + TweetNaCl.BoxBoxZeroBytes)
         {
             throw new NKeysException("Encrypted input is not valid");
         }
@@ -282,7 +282,14 @@ public sealed class KeyPair : IDisposable
         Array.Copy(input, Vlen, nonce, 0, CurveNonceLen);
         var spub = DecodePubCurveKey(sender);
 
-        return TweetNaCl.CryptoBoxOpen(input.AsSpan().Slice(Vlen + CurveNonceLen).ToArray(), nonce, spub, _seed)!;
+        try
+        {
+            return TweetNaCl.CryptoBoxOpen(input.AsSpan().Slice(Vlen + CurveNonceLen).ToArray(), nonce, spub, _seed)!;
+        }
+        catch (Exception ex) when (ex is not NKeysException)
+        {
+            throw new NKeysException("Decryption failed");
+        }
     }
 
     /// <summary>

--- a/NATS.NKeys/KeyPair.cs
+++ b/NATS.NKeys/KeyPair.cs
@@ -286,9 +286,9 @@ public sealed class KeyPair : IDisposable
         {
             return TweetNaCl.CryptoBoxOpen(input.AsSpan().Slice(Vlen + CurveNonceLen).ToArray(), nonce, spub, _seed)!;
         }
-        catch (TweetNaCl.NKeyNaclException)
+        catch (TweetNaCl.NKeyNaclException ex)
         {
-            throw new NKeysException("Decryption failed");
+            throw new NKeysException("Decryption failed", ex);
         }
     }
 

--- a/NATS.NKeys/NKeysException.cs
+++ b/NATS.NKeys/NKeysException.cs
@@ -5,5 +5,5 @@ namespace NATS.NKeys
     /// <summary>
     /// Represents an exception specific to the NKeys library.
     /// </summary>
-    public class NKeysException(string message) : Exception(message);
+    public class NKeysException(string message, Exception? innerException = null) : Exception(message, innerException);
 }

--- a/NATS.NKeys/PublicAPI.Unshipped.txt
+++ b/NATS.NKeys/PublicAPI.Unshipped.txt
@@ -10,7 +10,7 @@ NATS.NKeys.KeyPair.Seal(byte[]! data, string! receiver) -> byte[]!
 NATS.NKeys.KeyPair.Sign(System.ReadOnlyMemory<byte> message, System.Memory<byte> signature) -> void
 NATS.NKeys.KeyPair.Verify(System.ReadOnlyMemory<byte> message, System.ReadOnlyMemory<byte> signature) -> bool
 NATS.NKeys.NKeysException
-NATS.NKeys.NKeysException.NKeysException(string! message) -> void
+NATS.NKeys.NKeysException.NKeysException(string! message, System.Exception? innerException = null) -> void
 NATS.NKeys.PrefixByte
 NATS.NKeys.PrefixByte.Account = 0 -> NATS.NKeys.PrefixByte
 NATS.NKeys.PrefixByte.Cluster = 16 -> NATS.NKeys.PrefixByte


### PR DESCRIPTION
Open() had two issues: short ciphertext (29-43 bytes) passed the length check but caused OverflowException from a negative array allocation in TweetNaCl, and auth failures threw InvalidCipherTextException (not a subclass of NKeysException) so callers catching NKeysException would miss decryption errors. Tightened the minimum input length and wrapped the TweetNaCl call to normalize exceptions.

- [x] `Open_rejects_short_input` (0, 28, 29, 43 bytes all throw NKeysException)
- [x] `DecodePubCurveKey_blackbox_tampered_ciphertext_fails` (tampered ciphertext throws NKeysException)
- [x] `DecodePubCurveKey_blackbox_wrong_sender_fails_open` (wrong sender throws NKeysException)
- [x] `DecodePubCurveKey_blackbox_wrong_receiver_fails_open` (wrong receiver throws NKeysException)