### PR TITLE
Wipe intermediate key material

### DIFF
--- a/NATS.NKeys/NaCl/Internal/Ed25519Ref10/sign.cs
+++ b/NATS.NKeys/NaCl/Internal/Ed25519Ref10/sign.cs
@@ -75,9 +75,10 @@ namespace NATS.NKeys.NaCl.Internal.Ed25519Ref10
             byte[] m, int moffset, int mlen,
             byte[] sk, int skoffset)
         {
-            byte[] az, r, hram;
+            byte[] az = null, r = null, hram = null;
             GroupElementP3 R;
-            var hasher = new Sha512();
+            using var hasher = new Sha512();
+            try
             {
                 hasher.Update(sk, skoffset, 32);
                 az = hasher.Finalize();
@@ -104,6 +105,12 @@ namespace NATS.NKeys.NaCl.Internal.Ed25519Ref10
                 NATS.NKeys.NaCl.Internal.Ed25519Ref10.ScalarOperations.sc_muladd(s, hram, az, r);
                 Array.Copy(s, 0, sig, sigoffset + 32, 32);
                 CryptoBytes.Wipe(s);
+            }
+            finally
+            {
+                if (az != null) CryptoBytes.Wipe(az);
+                if (r != null) CryptoBytes.Wipe(r);
+                if (hram != null) CryptoBytes.Wipe(hram);
             }
         }
     }

--- a/NATS.NKeys/NaCl/TweetNaCl.cs
+++ b/NATS.NKeys/NaCl/TweetNaCl.cs
@@ -185,7 +185,14 @@ internal class TweetNaCl
     public static Byte[] CryptoBoxBeforenm(Byte[] publicKey, Byte[] secretKey)
     {
         Byte[] s = CryptoScalarmult(secretKey, publicKey);
-        return CryptoCoreHSalsa20(_0, s, Sigma);
+        try
+        {
+            return CryptoCoreHSalsa20(_0, s, Sigma);
+        }
+        finally
+        {
+            Array.Clear(s, 0, s.Length);
+        }
     }
 
     /// <summary>
@@ -231,7 +238,14 @@ internal class TweetNaCl
     public static Byte[] CryptoBox(Byte[] message, Byte[] nonce, Byte[] publicKey, Byte[] secretKey)
     {
         Byte[] k = CryptoBoxBeforenm(publicKey, secretKey);
-        return CryptoBoxAfternm(message, nonce, k);
+        try
+        {
+            return CryptoBoxAfternm(message, nonce, k);
+        }
+        finally
+        {
+            Array.Clear(k, 0, k.Length);
+        }
     }
 
     /// <summary>
@@ -249,7 +263,14 @@ internal class TweetNaCl
     public static Byte[] CryptoBoxOpen(Byte[] cipheredMessage, Byte[] nonce, Byte[] publicKey, Byte[] secretKey)
     {
         Byte[] k = CryptoBoxBeforenm(publicKey, secretKey);
-        return CryptoBoxOpenAfternm(cipheredMessage, nonce, k);
+        try
+        {
+            return CryptoBoxOpenAfternm(cipheredMessage, nonce, k);
+        }
+        finally
+        {
+            Array.Clear(k, 0, k.Length);
+        }
     }
 
     /// <summary>

--- a/NATS.NKeys/X25519/X25519.cs
+++ b/NATS.NKeys/X25519/X25519.cs
@@ -20,61 +20,67 @@ namespace X25519
         private static byte[] ScalarMult(byte[] input, byte[] baseIn)
         {
             var e = new byte[32];
+            try
+            {
+                Array.Copy(input,e,32); //copy(e[:], input[:])
+                e[0] &= 248;
+                e[31] &= 127;
+                e[31] |= 64;
 
-            Array.Copy(input,e,32); //copy(e[:], input[:])
-            e[0] &= 248;
-            e[31] &= 127;
-            e[31] |= 64;
+                FieldElement x1, x2, z2, x3, z3, tmp0, tmp1;
+                z2 = new FieldElement();
+                // feFromBytes(&x1, base)
+                x1 = new FieldElement(baseIn); //SECOND NUMBER
+                //feOne(&x2)
+                x2 = new FieldElement();
+                x2.One();
+                //feCopy(&x3, &x1)
+                x3 = new FieldElement();
+                FieldElement.Copy(ref x3,x1);
+                //feOne(&z3)
+                z3 = new FieldElement();
+                z3.One();
 
-            FieldElement x1, x2, z2, x3, z3, tmp0, tmp1;
-            z2 = new FieldElement();
-            // feFromBytes(&x1, base)
-            x1 = new FieldElement(baseIn); //SECOND NUMBER
-            //feOne(&x2)
-            x2 = new FieldElement();
-            x2.One();
-            //feCopy(&x3, &x1)
-            x3 = new FieldElement();
-            FieldElement.Copy(ref x3,x1);
-            //feOne(&z3)
-            z3 = new FieldElement();
-            z3.One();
+                int swap = 0;
+                for (int pos = 254; pos >= 0; pos--) {
+                    byte b = Convert.ToByte(e[pos / 8] >> (pos & 7));
+                    b &= 1;
+                    swap ^= (int)(b);
+                    FieldElement.CSwap(ref x2, ref x3, swap);
+                    FieldElement.CSwap(ref z2, ref z3, swap);
+                    swap = (int) (b);
 
-            int swap = 0;
-            for (int pos = 254; pos >= 0; pos--) {
-                byte b = Convert.ToByte(e[pos / 8] >> (pos & 7));
-                b &= 1;
-                swap ^= (int)(b);
+                    tmp0 = x3 - z3; //feSub(&tmp0, &x3, &z3)
+                    tmp1 = x2 - z2; //feSub(&tmp1, &x2, &z2)
+                    x2 += z2; //feAdd(&x2, &x2, &z2)
+                    z2 = x3 + z3; //feAdd(&z2, &x3, &z3)
+                    z3 = tmp0.Multiply(x2);
+                    z2 = z2.Multiply(tmp1);
+                    tmp0 = tmp1.Square();
+                    tmp1 = x2.Square();
+                    x3 = z3 + z2; //feAdd(&x3, &z3, &z2)
+                    z2 = z3 - z2; //feSub(&z2, &z3, &z2)
+                    x2 = tmp1.Multiply(tmp0);
+                    tmp1 -= tmp0;//feSub(&tmp1, &tmp1, &tmp0)
+                    z2 = z2.Square();
+                    z3 = tmp1.Mul121666();
+                    x3 = x3.Square();
+                    tmp0 += z3; //feAdd(&tmp0, &tmp0, &z3)
+                    z3 = x1.Multiply(z2);
+                    z2 = tmp1.Multiply(tmp0);
+                }
+
                 FieldElement.CSwap(ref x2, ref x3, swap);
                 FieldElement.CSwap(ref z2, ref z3, swap);
-                swap = (int) (b);
 
-                tmp0 = x3 - z3; //feSub(&tmp0, &x3, &z3)
-                tmp1 = x2 - z2; //feSub(&tmp1, &x2, &z2)
-                x2 += z2; //feAdd(&x2, &x2, &z2)
-                z2 = x3 + z3; //feAdd(&z2, &x3, &z3)
-                z3 = tmp0.Multiply(x2);
-                z2 = z2.Multiply(tmp1);
-                tmp0 = tmp1.Square();
-                tmp1 = x2.Square();
-                x3 = z3 + z2; //feAdd(&x3, &z3, &z2)
-                z2 = z3 - z2; //feSub(&z2, &z3, &z2)
-                x2 = tmp1.Multiply(tmp0);
-                tmp1 -= tmp0;//feSub(&tmp1, &tmp1, &tmp0)
-                z2 = z2.Square();
-                z3 = tmp1.Mul121666();
-                x3 = x3.Square();
-                tmp0 += z3; //feAdd(&tmp0, &tmp0, &z3)
-                z3 = x1.Multiply(z2);
-                z2 = tmp1.Multiply(tmp0);
+                z2 = z2.Invert();
+                x2 = x2.Multiply(z2);
+                return x2.ToBytes();
             }
-
-            FieldElement.CSwap(ref x2, ref x3, swap);
-            FieldElement.CSwap(ref z2, ref z3, swap);
-
-            z2 = z2.Invert();
-            x2 = x2.Multiply(z2);
-            return x2.ToBytes();
+            finally
+            {
+                Array.Clear(e, 0, e.Length);
+            }
         }
         /// <summary>
         /// X25519 returns the result of the scalar multiplication (scalar * point),


### PR DESCRIPTION
Several crypto operations left sensitive intermediate byte arrays on the managed heap after use. This adds try/finally blocks with Array.Clear to wipe them. Best-effort given GC can relocate arrays, but reduces the number of live copies containing key material.

Locations:
- Ed25519 sign: expanded key (az), nonce (r), hram
- X25519 ScalarMult: clamped private key copy (e)
- TweetNaCl CryptoBox/CryptoBoxOpen: shared key (k)
- TweetNaCl CryptoBoxBeforenm: DH intermediate (s)

Also adds using/dispose for the Sha512 hasher in sign.

- [x] `Create_key_pair` (sign/verify roundtrip)
- [x] `XKey_seal_open_compare_to_Go_nkeys_library` (seal/open cross-validated with Go)
- [x] `XKey_seal_open` (seal/open roundtrip)
- [x] `DecodePubCurveKey_blackbox_seal_open_with_decoded_key` (seal/open multiple payload sizes)
- [x] All 43 NKeys + 56 NaCl tests pass across 4 target frameworks