### PR TITLE
Release trigger tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,11 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types:
+      - published
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   nuget:
@@ -16,42 +15,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - id: tag
-        name: Determine tag
+      - name: Validate tag
         run: |
-          version="$(head -n 1 version.txt)"
-          ref_name="v$version"
-          create=true
-          if [ "$(git ls-remote origin "refs/tags/$ref_name" | wc -l)" = "1" ]; then
-            create=false
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          file_version="$(head -n 1 version.txt)"
+          if [ "$version" != "$file_version" ]; then
+            echo "::error::Tag version ($version) does not match version.txt ($file_version)"
+            exit 1
           fi
 
-          echo "version=$version" | tee -a "$GITHUB_OUTPUT"
-          echo "ref-name=$ref_name" | tee -a "$GITHUB_OUTPUT"
-          echo "create=$create" | tee -a "$GITHUB_OUTPUT"
-
-      - if: ${{ fromJSON(steps.tag.outputs.create) }}
-        name: Setup dotnet
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
             dotnet-version: '10.x'
 
-      - if: ${{ fromJSON(steps.tag.outputs.create) }}
-        name: Pack
+      - name: Pack
         # https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg
         # https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
         run: dotnet pack -c Release -o dist -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:ContinuousIntegrationBuild=true
 
-      - if: ${{ fromJSON(steps.tag.outputs.create) }}
-        name: Push
+      - name: Push
         run: |
           cd dist
           ls -lh
-          # this should upload snupkgs in the same folder
           dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k "${{ secrets.NUGET_API_KEY }}" --skip-duplicate
-
-      - if: ${{ fromJSON(steps.tag.outputs.create) }}
-        name: Tag
-        run: |
-          git tag "${{ steps.tag.outputs.ref-name }}"
-          git push origin "${{ steps.tag.outputs.ref-name }}"


### PR DESCRIPTION
Switch NuGet release workflow from push-to-main trigger to GitHub Release published event. This adds a human gate to the publish process, the release workflow only runs when a maintainer explicitly creates and publishes a GitHub Release (which also creates the tag). A validation step ensures the tag matches version.txt before pushing to NuGet.

cc @philpennock, @aricart, @Jarema 