### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ on:
     types:
       - published
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   nuget:


### PR DESCRIPTION
Set explicit `contents: read` permission instead of empty `permissions: {}` so checkout doesn't rely on unauthenticated HTTPS.