### PR TITLE
Add missing workflow permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,9 @@ on:
   # to be removed. only needed for the initial setup. running on pull requests is enough.
   push: { branches: [ main ] }
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   dotnet:
     name: dotnet


### PR DESCRIPTION
Adds explicit `contents: read` permission to the test and format workflows, which were missing a permissions declaration, matching the existing release workflow.